### PR TITLE
How to remove space between header and content of TabItem in WPF DockingManager

### DIFF
--- a/How-to-remove-space-between-header-and-content-of-tabitem-in-wpf-dockingmanager/README.md
+++ b/How-to-remove-space-between-header-and-content-of-tabitem-in-wpf-dockingmanager/README.md
@@ -1,3 +1,5 @@
 # How to remove space between header and content of TabItem in WPF DockingManager?
 
 You can reduce the space between TabItem header and the content of the TabItem by customizing the margin value of the ContentPresenter(“PART_SelectedContentHost”) in which we have placed the actual content of TabItem in [WPF DockingManager](https://www.syncfusion.com/wpf-controls/docking).
+
+KB article - [How to remove space between header and content of TabItem in WPF DockingManager?](https://www.syncfusion.com/kb/8834/how-to-remove-space-between-header-and-content-of-tabitem-in-wpf-dockingmanager)


### PR DESCRIPTION
documentation(DOC-3343): KB link