### PR TITLE
How to hide the drag providers when trying to dock the window in WPF DockingManager

### DIFF
--- a/How-to-hide-the-drag-providers-when-trying-to-dock-the-window-in-dockingmanager/README.md
+++ b/How-to-hide-the-drag-providers-when-trying-to-dock-the-window-in-dockingmanager/README.md
@@ -1,3 +1,5 @@
 # How to hide the drag providers when trying to dock the window in WPF DockingManager?
 
 Drag provider will be visible only if we try to dock the float window by dragging it. If the floated window is not dockable, the drag providers will not show in [WPF DockingManager](https://www.syncfusion.com/wpf-controls/docking). To hide the drag providers from the DockingManager, we must set CanDock property of DockingManager as false. For instance, we have set the value of CanDock property as false, when trying to dock the float window to the DockingManager.
+
+KB article - [How to hide the drag providers when trying to dock the window in WPF DockingManager?](https://www.syncfusion.com/kb/8788/how-to-hide-the-drag-providers-when-trying-to-dock-the-window-in-wpf-dockingmanager)


### PR DESCRIPTION
documentation(DOC-3343): KB link